### PR TITLE
Feat: drag y

### DIFF
--- a/MAPS_Web/dist/frappe-gantt.js
+++ b/MAPS_Web/dist/frappe-gantt.js
@@ -543,7 +543,6 @@ var Gantt = (function () {
         }
     
         draw() {
-            this.draw_number();
             this.draw_bar();
             this.draw_progress_bar();
             this.draw_label();
@@ -595,17 +594,6 @@ var Gantt = (function () {
             });
             // labels get BBox in the next tick
             requestAnimationFrame(() => this.update_label_position());
-        }
-    
-        // Add grid line number
-        draw_number() {
-            createSVG('text', {
-                x: 15,
-                y: this.y + this.height / 2,
-                innerHTML: this.task.id,
-                class: 'process-num',
-                append_to: this.bar_group
-            });
         }
     
         draw_resize_handles() {
@@ -1452,6 +1440,7 @@ var Gantt = (function () {
             this.make_grid_header();
             this.make_grid_ticks();
             this.make_grid_highlights();
+            this.make_grid_row_number();
         }
     
         make_grid_background() {
@@ -1536,6 +1525,27 @@ var Gantt = (function () {
                 append_to: this.layers.score,
                 id: 'score'
             });
+        }
+
+        // Add line number
+        make_grid_row_number() {
+            const rows_layer = createSVG('g', { append_to: this.layers.grid });
+            const row_height = this.options.bar_height + this.options.padding;
+            let row_y = this.options.header_height + this.options.padding
+
+            var count = 1
+            for (let task of this.tasks) {
+                const line_number = createSVG('text', {
+                    x: 15,
+                    y: row_y*0.6 + count * row_height,
+                    class: 'process-num',
+                    append_to: rows_layer
+                })
+
+                line_number.textContent = count;
+
+                count = count + 1;
+            }
         }
     
         update_score() {

--- a/MAPS_Web/dist/frappe-gantt.js
+++ b/MAPS_Web/dist/frappe-gantt.js
@@ -1237,6 +1237,10 @@ var Gantt = (function () {
     
                 // cache index
                 task._index = i;
+
+                if (typeof task.machine_index === 'number') {
+                    task._index = task.machine_index;
+                }
     
                 // invalid dates
                 if (!task.start && !task.end) {

--- a/MAPS_Web/index.html
+++ b/MAPS_Web/index.html
@@ -71,6 +71,7 @@
 	<script>
 		var tasks = [
 			{
+				machine_index: 0,
 				start: '2022-01-01',
 				end: '2022-01-10',
 				name: '본체 성형',
@@ -80,6 +81,7 @@
 				custom_class: 'TASK1'
 			},
 			{
+				machine_index: 0,
 				start: '2022-01-17',
 				end: '2022-01-22',
 				name: '본체 도장',
@@ -90,6 +92,7 @@
 				custom_class: 'TASK2'
 			},
 			{
+				machine_index: 2,
 				start: '2022-01-12',
 				end: '2022-01-15',
 				name: '부품 가공',
@@ -99,6 +102,7 @@
 				custom_class: 'TASK3'
 			},
 			{
+				machine_index: 3,
 				start: '2022-01-24',
 				end: '2022-01-29',
 				name: '본체 및 부품 조립',
@@ -109,6 +113,7 @@
 				custom_class: 'TASK4'
 			},
 			{
+				machine_index: 4,
 				start: '2022-01-30',
 				end: '2022-02-01',
 				name: '품질 검사',
@@ -119,6 +124,7 @@
 				custom_class: 'TASK5'
 			},
 			{
+				machine_index: 5,
 				start: '2022-02-02',
 				end: '2022-02-03',
 				name: '서류 작업',
@@ -128,6 +134,7 @@
 				custom_class: 'TASK6'
 			},
 			{
+				machine_index: 6,
 				start: '2022-02-04',
 				end: '2022-02-07',
 				name: '다음 공정으로 이송',
@@ -138,6 +145,7 @@
 				custom_class: 'TASK7'
 			},
 			{
+				machine_index: 7,
 				start: '2022-02-08',
 				end: '2022-02-09',
 				name: '서류 작업 2',


### PR DESCRIPTION
- line number 출력 구조 수정
기존: 작업바와 하나의 그룹으로, 작업의 id값을 출력
수정 후: js 내부에서 task의 수를 count하여 출력

- 각 line을 machine으로 볼 수 있도록, task의 index를 machine_index로 받아올 수 있도록 수정

- 세로로 drag 가능하게
https://github.com/frappe/gantt/pull/278
위 issue 참고하여 sortable 기능 추가